### PR TITLE
remove confusion around .env, remove sensitive values from docker-compose.yml

### DIFF
--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -15,8 +15,6 @@ services:
     networks:
       - app-tier   
     restart: always
-    environment:
-      DB_HOST: db
     env_file:
       - .env.local
     extra_hosts:
@@ -29,24 +27,5 @@ services:
       - 3306
     networks:
       - app-tier
-    environment:
-    ############################################################
-    ## The following variables NEED to be set before execution.
-    ############################################################
-      
-      #DB_NAME and MYSQL_DATABASE must be the same.
-      MYSQL_DATABASE: sample_install_mmdm
-      
-      # This is the user name and password of your mysql user that will be created. These values must be used in DB_USER and DB_PASS variables in the .env file that you will create.
-      MYSQL_USER: myuser
-      MYSQL_PASSWORD: mypassword
-
-      # This defines the root password of mysql in the container. You can use the root user too. 
-      MYSQL_ROOT_PASSWORD: root
-    ############################################################
-    ## The following variables are advanced settings,
-    ## and must be only changed in case you're trying something
-    ## specific.
-    ############################################################
-      MYSQL_ALLOW_EMPTY_PASSWORD: ok
-      MYSQL_ROOT_HOST: '%'
+    env_file:
+      - .env.local

--- a/sample.env.local.docker
+++ b/sample.env.local.docker
@@ -3,14 +3,41 @@
 ############################################################
 
 NEXT_PUBLIC_BASE_URL= "http://localhost:3000/"
+NEXT_PUBLIC_API_URL="http://localhost:3000/api"
 
 ## Database variables.
-DB_HOST=localhost
+DB_HOST=db
+
 DB_USER=myuser
-DB_PASS=mypassword
+MYSQL_USER: myuser
+
+DB_PASS=mypassword_changeme
+MYSQL_PASSWORD: mypassword_changeme
+
+#DB_NAME and MYSQL_DATABASE must be the same.
 DB_NAME=dbname
+MYSQL_DATABASE: sample_install_mmdm
+
+
 DB_CHARSET="utf8mb4"
 DB_COLLATE="utf8mb4_0900_ai_ci"
+environment:
+############################################################
+## The following variables NEED to be set before execution.
+############################################################
+
+
+# This is the user name and password of your mysql user that will be created. These values must be used in DB_USER and DB_PASS variables in the .env file that you will create.
+
+# This defines the root password of mysql in the container. You can use the root user too. 
+MYSQL_ROOT_PASSWORD: root_changeme
+############################################################
+## The following variables are advanced settings,
+## and must be only changed in case you're trying something
+## specific.
+############################################################
+MYSQL_ALLOW_EMPTY_PASSWORD: ok
+MYSQL_ROOT_HOST: '%'
 
 ## AES Encryption Password
 ## This is used to encrypt CalDAV password in the database.
@@ -59,8 +86,6 @@ ENFORCE_SESSION_TIMEOUT=true
 #Whether user is running install from a docker image.
 DOCKER_INSTALL="true"
 
-## General Config
-NEXT_PUBLIC_API_URL="http://localhost:3000/api"
 
 ## Debug Mode
 NEXT_PUBLIC_DEBUG_MODE=true


### PR DESCRIPTION
This moves all sensitive values to one location (.env.local), instead of partially in docker-compose. see #92 