### PR TITLE
- bump to version 0.3.6

### DIFF
--- a/COMMITMESSAGE.md
+++ b/COMMITMESSAGE.md
@@ -1,6 +1,2 @@
-- Bump version to 0.3.5
-- Changed a few variable in docker-compose sample file
-    - Now user can choose to create a new user for mysql docker container.
-    - Changed sample .env file to make sure it is compatible out of the box with docker-compose.yml.sample.
-    - Made changed to docs to reflect these changes.
-    - Upgrade some dependencies, as per dependabot alerts.
+- bump to version 0.3.6
+- Calendar and Caldav account names are now stored locally to improve performace by limiting calls to API.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manage-my-damn-life-nextjs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/common/calendars/caldavAccounts/CaldavAccounts.js
+++ b/src/components/common/calendars/caldavAccounts/CaldavAccounts.js
@@ -17,6 +17,7 @@ import AddNewCalendar from "../AddNewCalendar";
 import { getAuthenticationHeadersforUser } from "@/helpers/frontend/user";
 import { getMessageFromAPIResponse } from "@/helpers/frontend/response";
 import { getAPIURL } from "@/helpers/general";
+import { setUserCalendarStorageVar } from "@/helpers/frontend/localstorage";
 
 export default class CaldavAccounts extends Component{
     constructor(props)
@@ -126,6 +127,7 @@ export default class CaldavAccounts extends Component{
                         </Col>
                     </Row>)
                     */
+                   setUserCalendarStorageVar(caldav_accounts.data.message)
                     for(let j=0; j<caldav_accounts.data.message.length; j++)
                     {
                         var calendars=[]

--- a/src/components/tasks/TaskEditor.js
+++ b/src/components/tasks/TaskEditor.js
@@ -31,6 +31,7 @@ import { VTODO } from "@/helpers/frontend/classes/VTODO";
 import { RecurrenceHelper } from "@/helpers/frontend/classes/RecurrenceHelper";
 import { getStandardDateFormat } from "@/helpers/frontend/settings";
 import { getErrorResponse } from "@/helpers/errros";
+import { getUserCalendarsFromLocalStorage, setUserCalendarStorageVar } from "@/helpers/frontend/localstorage";
 export default class TaskEditor extends Component {
     constructor(props) {
         super(props)
@@ -283,8 +284,17 @@ export default class TaskEditor extends Component {
         this.getLabels()
     }
     async generateCalendarName() {
-        var calendarsFromServer = await caldavAccountsfromServer()
-        this.setState({calendarsFromServer: calendarsFromServer})
+        const calendarsFromCookies= getUserCalendarsFromLocalStorage()
+        console.log("calendarsFromCookies", calendarsFromCookies)
+        if(varNotEmpty(calendarsFromCookies)){
+            this.setState({calendarsFromServer: calendarsFromCookies})
+
+        }else{
+            var calendarsFromServer = await caldavAccountsfromServer()
+            setUserCalendarStorageVar(calendarsFromServer)
+            this.setState({calendarsFromServer: calendarsFromServer})
+    
+        }
     }
 
     getCalendarDDL()

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,4 +1,4 @@
-export const VERSION_NUMBER = "0.3.5"
+export const VERSION_NUMBER = "0.3.6"
 /*
 * SYSTEM_DEFAULT_LABEL_PREFIX: Default prefix applied to all system generated labels like
 * "My Day"

--- a/src/helpers/frontend/cookies.js
+++ b/src/helpers/frontend/cookies.js
@@ -2,6 +2,7 @@ import Cookies from 'js-cookie'
 import { getAuthenticationHeadersforUser } from './user'
 import { getAPIURL, logVar, varNotEmpty } from '../general'
 import { getMessageFromAPIResponse } from './response'
+import { clearLocalStorage } from './localstorage'
 
 export function deleteAllCookies(){
     Cookies.remove("DEFAULT_CALENDAR_ID")
@@ -13,8 +14,8 @@ export function deleteAllCookies(){
     Cookies.remove("USER_PREFERENCE_CALENDARS_TO_SHOW")
     Cookies.remove("SSID")
     Cookies.remove("MMDL_CALENDAR_START_DAY")
-
-    
+    Cookies.remove("MMDL_USER_CALENDARS")
+    clearLocalStorage()
     
 }
 export function setCookie(cname, cvalue, exdays=10000)
@@ -68,7 +69,6 @@ export async function getDefaultCalendarID()
     })
 
 }
-
 export function setDefaultCalendarID(calendars_id)
 {
     Cookies.set("DEFAULT_CALENDAR_ID", calendars_id, { expires: 3650 })

--- a/src/helpers/frontend/localstorage.js
+++ b/src/helpers/frontend/localstorage.js
@@ -1,0 +1,39 @@
+export function clearLocalStorage(){
+    try{
+        localStorage.clear();
+    }catch(e){
+        console.error("deleteAllCookies", e)
+    }
+}
+/**
+ * Saves calendar names from server to user storage.
+ * @param {*} calendarsFromServer Calendar data from API
+ */
+export function setUserCalendarStorageVar(calendarsFromServer){
+    try{
+
+        const toStore= JSON.stringify(calendarsFromServer)
+        localStorage.setItem("MMDL_USER_CALENDARS", toStore)
+    }
+    catch(e){
+        console.warn("setUserCalendarStorageVar", e)
+    }
+}
+
+/**
+ * Get the array of Calendars and caldav accounts from LocalStorage.
+ * @returns Array of Calendars and Caldav accounts from Local storage. 
+ */
+export function getUserCalendarsFromLocalStorage(){
+    try{
+        const userCalendarString= localStorage.getItem("MMDL_USER_CALENDARS")
+   
+        const toReturn = JSON.parse(userCalendarString)
+        return toReturn
+    }
+    catch(e){
+        console.warn("getUserCalendarsFromLocalStorage", e)
+        return null
+    }
+
+}


### PR DESCRIPTION
- Calendar and Caldav account names are now stored locally to improve performace by limiting calls to API.