### PR TITLE
Remove dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Manage my Damn Life (MMDL) is a self hosted front end for managing your CalDAV t
 
 ![Task View](docs/pics/screenshots/TaskView.png "Task View")
 ![Home](docs/pics/screenshots/HomeView.png "Task View")
-![GanttView](docs/pics/screenshots/GanttView.png "Task View")
 
 More screenshots are available in the directory '/docs/pics/screenshots'
 


### PR DESCRIPTION
Remove the dead link to "GanttView" in the docs.
The file got deleted in the [Commit](https://github.com/intri-in/manage-my-damn-life-nextjs/commit/fc0d52105529f80bc209d242f3b4b1be8156baae) (fc0d521)