### PR TITLE
Add DB_PORT support to Sequelize config and migration

### DIFF
--- a/runSequelizeMigrations.js
+++ b/runSequelizeMigrations.js
@@ -17,7 +17,7 @@ import { readdir } from 'fs/promises'
 
   return new Promise((resolve, reject) => {
     const migrate = exec(
-      "npx sequelize-cli db:migrate --env=local --url 'mysql://"+process.env.DB_USER+":"+process.env.DB_PASS+"@"+process.env.DB_HOST+"/"+process.env.DB_NAME+"'",
+      "npx sequelize-cli db:migrate --env=local --url 'mysql://"+process.env.DB_USER+":"+process.env.DB_PASS+"@"+process.env.DB_HOST+":"+process.env.DB_PORT+"/"+process.env.DB_NAME+"'",
       {env: process.env},
       err => (err ? reject(err): resolve(true))
     );

--- a/src/helpers/api/db.js
+++ b/src/helpers/api/db.js
@@ -43,6 +43,7 @@ export function getSequelizeObj(){
     process.env.DB_PASS,
      {
        host: process.env.DB_HOST,
+       port: process.env.DB_PORT,
        dialect: 'mysql',
        dialectModule: require('mysql2'),
      });


### PR DESCRIPTION
## Changes introduced

- Added `db_port` support in Sequelize CLI migration command.
- Passed `db_port` into Sequelize constructor from config.

## Reason

This allows specifying a custom database port for environments where the default (e.g., 3306 for MySQL) cannot be used.

