### PR TITLE
UI Fix: Calendar view did not show the name of the day. Now the "ddd"…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ v0.8.3
     - While moving/copying, the user now has the option to move/copy all the subtasks as well.
     - Clicking on sync now allows the user to request a fresh sync. May be useful in some cases.
 
+- UI Fix: 
+    - Calendar view now shows the name of the day.
+    
 - Bug Fixes:
     - Fixed #271
         - Bug was caused because Jotai was only getting a static value. It now fetches value from setting.

--- a/COMMITMESSAGE.md
+++ b/COMMITMESSAGE.md
@@ -1,1 +1,2 @@
-Bug fix: Webcal shows the summary of the event, instead of description in "Calendar View".
+UI Fix: Calendar view did not show the name of the day. Now the "ddd" string is added to dateFormat, in case the user has not added the name of the day in the settings explicitly
+    

--- a/src/components/fullcalendar/CalendarViewWithStateManagement.tsx
+++ b/src/components/fullcalendar/CalendarViewWithStateManagement.tsx
@@ -551,6 +551,14 @@ export const CalendarViewWithStateManagement = ({ calendarAR }: { calendarAR: nu
     if (varNotEmpty(caldav_accounts) && Array.isArray(caldav_accounts) && caldav_accounts.length > 0) {
         calendarsSelect = <ListGroupCalDAVAccounts onChange={userPreferencesChanged} caldav_accounts={caldav_accounts} />
     }
+    const addDayNameInHeader = () =>{
+        if(dateFormat){
+            if(dateFormat.includes("dd") || dateFormat.includes("ddd") || dateFormat.includes("dddd") ){
+               return dateFormat 
+            }
+            return `${dateFormat} ddd`
+        }
+    }
     return (
 
         <>
@@ -599,7 +607,7 @@ export const CalendarViewWithStateManagement = ({ calendarAR }: { calendarAR: nu
                 locale={i18n.language}
                 titleFormat={dateFormat} 
                 eventTimeFormat={timeFormat ?? "HH:mm"}
-                dayHeaderFormat={dateFormat?? "DD/MM/YYYY"}
+                dayHeaderFormat={dateFormat? `${addDayNameInHeader()}` :  "DD/MM/YYYY ddd"}
                 slotLabelFormat={timeFormat?? "HH:mm"}
             />
         </>


### PR DESCRIPTION
… string is added to dateFormat, in case the user has not added the name of the day in the settings explicitly